### PR TITLE
Fixed panic on vat.Validate("vat") without countries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        go-version: [ 1.16.x, 1.17.x ]
+        go-version: [ 1.16.x, 1.17.x, 1.22.x, 1.23.x ]
         platform: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ stored in a database.
 ## :gear: Installation
 
 Go v1.17.x or newer (RECOMMENDED)
+
 ```
 go install github.com/ltns35/go-vat
 ```
 
 Go v1.16.x or older
+
 ```
 go get -u github.com/ltns35/go-vat
 ```
@@ -141,8 +143,10 @@ merged.
 
 ## :test_tube: Testing
 
-The library is tested against the 2 latest stable major versions of Go.
+The library is tested against the 4 latest stable major versions of Go.
 
+- 1.23.x
+- 1.22.x
 - 1.17.x
 - 1.16.x
 

--- a/validator.go
+++ b/validator.go
@@ -180,7 +180,7 @@ func Validate(vat string, countriesList ...countries.Calculer) (*CheckResult, er
 
 	cleanVAT := removeExtraChars(vat)
 
-	if countriesList[0] == nil {
+	if len(countriesList) == 0 {
 		countriesList = allCountries
 	}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -722,7 +722,7 @@ func TestCheckVAT(t *testing.T) {
 
 						got := new(CheckResult)
 
-						if &tt.country == nil {
+						if tt.country == nil {
 							got, _ = Validate(value)
 						} else {
 							got, _ = Validate(value, tt.country)


### PR DESCRIPTION
Following the example below, it was throwing a panic

```go
// Check against all supported countries validators.
vatResult, err := vat.Validate("ADE000000E")
if err != nil {
    // Handle error
}
```

Also changed the tests to catch this issue and updated the tested go versions.

Feedback is welcome